### PR TITLE
Fix Missing Originating Source File

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0-beta04'
+        classpath 'com.android.tools.build:gradle:4.0.0-rc01'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -24,7 +24,7 @@ allprojects {
 subprojects {
     // group = 'com.juullabs.exercise'
     group = 'com.github.juullabs-oss.android-exercise'
-    version = '0.6.0'
+    version = '0.6.1'
 }
 
 task clean(type: Delete) {

--- a/compile/src/main/java/com/juullabs/exercise/compile/generator/code/NewFragmentFunctionCodeGenerator.kt
+++ b/compile/src/main/java/com/juullabs/exercise/compile/generator/code/NewFragmentFunctionCodeGenerator.kt
@@ -6,14 +6,17 @@ import com.juullabs.exercise.compile.asBundleOf
 import com.juullabs.exercise.compile.asParameterSpecs
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
+import javax.lang.model.element.Element
 
 internal class NewFragmentFunctionCodeGenerator(
+    private val originatingElement: Element,
     private val targetClass: ClassName,
     private val params: Parameters
 ) : CodeGenerator {
 
     override fun addTo(fileSpec: FileSpec.Builder) {
         fileSpec.addFunction("new${targetClass.simpleName}") {
+            originatingElements += originatingElement
             returns(targetClass)
             addParameters(params.asParameterSpecs())
             addStatement("val instance = %T()", targetClass)

--- a/compile/src/main/java/com/juullabs/exercise/compile/generator/code/ParameterizedIntentClassCodeGenerator.kt
+++ b/compile/src/main/java/com/juullabs/exercise/compile/generator/code/ParameterizedIntentClassCodeGenerator.kt
@@ -13,8 +13,10 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
+import javax.lang.model.element.Element
 
 internal class ParameterizedIntentClassCodeGenerator(
+    private val originatingElement: Element,
     private val targetClass: ClassName,
     private val params: Parameters
 ) : CodeGenerator {
@@ -22,6 +24,7 @@ internal class ParameterizedIntentClassCodeGenerator(
     override fun addTo(fileSpec: FileSpec.Builder) {
         val className = ClassName(fileSpec.packageName, "${targetClass.simpleName}Intent")
         fileSpec.addClass(className) {
+            originatingElements += originatingElement
             superclass(intentTypeName)
             addIntentConstructor("context", contextTypeName, CodeBlock.of("context.packageName"))
             addIntentConstructor("packageName", stringTypeName, CodeBlock.of("packageName"))

--- a/compile/src/main/java/com/juullabs/exercise/compile/generator/code/ResultClassCodeGenerator.kt
+++ b/compile/src/main/java/com/juullabs/exercise/compile/generator/code/ResultClassCodeGenerator.kt
@@ -16,16 +16,19 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeSpec
+import javax.lang.model.element.Element
 
 private const val RETRIEVER = "data.get(\"\$packageName.%1L\")"
 
 internal class ResultClassCodeGenerator(
+    private val originatingElement: Element,
     private val targetClass: ClassName,
     private val resultKinds: List<ResultKind>
 ) : CodeGenerator {
     override fun addTo(fileSpec: FileSpec.Builder) {
         val className = ClassName(fileSpec.packageName, "${targetClass.simpleName}Result")
         fileSpec.addClass(className) {
+            originatingElements += originatingElement
             addModifiers(KModifier.SEALED)
             primaryConstructor { addParameter("data", bundleTypeName) }
             addProperty("data", bundleTypeName) { initializer("data") }

--- a/compile/src/main/java/com/juullabs/exercise/compile/generator/code/ResultContractClassCodeGenerator.kt
+++ b/compile/src/main/java/com/juullabs/exercise/compile/generator/code/ResultContractClassCodeGenerator.kt
@@ -14,8 +14,10 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import javax.lang.model.element.Element
 
 internal class ResultContractClassCodeGenerator(
+    private val originatingElement: Element,
     private val targetClass: ClassName,
     private val resultKinds: List<ResultKind>
 ): CodeGenerator {
@@ -24,6 +26,7 @@ internal class ResultContractClassCodeGenerator(
         val intentName = ClassName(fileSpec.packageName, "${targetClass.simpleName}Intent")
         val resultName = ClassName(fileSpec.packageName, "${targetClass.simpleName}Result")
         fileSpec.addClass(className) {
+            originatingElements += originatingElement
             superclass(activityResultContractTypeName.parameterizedBy(intentName, resultName.asNullable))
 
             primaryConstructor { addParameter("context", contextTypeName) }
@@ -56,7 +59,6 @@ internal class ResultContractClassCodeGenerator(
                 )
                 endControlFlow()
             }
-
         }
     }
 }

--- a/compile/src/main/java/com/juullabs/exercise/compile/generator/code/ResultSugarFunctionsCodeGenerator.kt
+++ b/compile/src/main/java/com/juullabs/exercise/compile/generator/code/ResultSugarFunctionsCodeGenerator.kt
@@ -1,52 +1,20 @@
 package com.juullabs.exercise.compile.generator.code
 
-import com.juullabs.exercise.compile.ResultKind
-import com.juullabs.exercise.compile.addFunction
-import com.juullabs.exercise.compile.asBundleOf
-import com.juullabs.exercise.compile.intentTypeName
-import com.juullabs.exercise.compile.reifyResultCode
+import com.juullabs.exercise.compile.*
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
+import javax.lang.model.element.Element
 
-/*fileSpecBuilder.addFunction("finish") {
-    receiver(typeClassName)
-    addParameter("result", resultTypeName)
-    beginControlFlow("val code = when (result) {")
-    for (kind in resultKinds) {
-        addStatement(
-            "is %T -> %L",
-            resultTypeName.nestedClass(kind.name),
-            reifyResultCode(kind.code)
-        )
-    }
-    endControlFlow()
-    addStatement("val data = Intent().apply { replaceExtras(result.data) }")
-    addStatement("setResult(code, data)")
-    addStatement("finish()")
-}
-
-for (kind in resultKinds) {
-    fileSpecBuilder.addFunction("finishWith${kind.name}") {
-        receiver(typeClassName)
-        for (param in kind.params) {
-            addParameter(param.name, param.combinedTypeName)
-        }
-        addCode(
-            "finish(%T(packageName, %L))",
-            resultTypeName.nestedClass(kind.name),
-            kind.params.toBundle("packageName")
-        )
-    }
-}
-*/
 internal class ResultSugarFunctionsCodeGenerator(
+    private val originatingElement: Element,
     private val targetClass: ClassName,
     private val resultKinds: List<ResultKind>
 ) : CodeGenerator {
     override fun addTo(fileSpec: FileSpec.Builder) {
         val className = ClassName(fileSpec.packageName, "${targetClass.simpleName}Result")
         fileSpec.addFunction("finishWith") {
+            originatingElements += originatingElement
             receiver(targetClass)
             addParameter("result", className)
             beginControlFlow("val code = when (result) {")

--- a/compile/src/main/java/com/juullabs/exercise/compile/generator/file/ActivityFileGenerator.kt
+++ b/compile/src/main/java/com/juullabs/exercise/compile/generator/file/ActivityFileGenerator.kt
@@ -31,16 +31,16 @@ internal class ActivityFileGenerator(
         val targetClass = element.asClassName()
         return FileSpec.build(targetClass.packageName, "${targetClass.simpleName}Exercise") {
             if (!element.modifiers.contains(Modifier.ABSTRACT)) {
-                addFrom(ParameterizedIntentClassCodeGenerator(targetClass, parameters))
+                addFrom(ParameterizedIntentClassCodeGenerator(element, targetClass, parameters))
             }
-            addFrom(GetExtrasClassCodeGenerator(targetClass, parameters))
+            addFrom(GetExtrasClassCodeGenerator(element, targetClass, parameters))
 
             val resultContractMirror = element.getAnnotation<ResultContract>()
             if (resultContractMirror != null) {
                 val kinds = getResultKinds(resultContractMirror)
-                addFrom(ResultContractClassCodeGenerator(targetClass, kinds))
-                addFrom(ResultClassCodeGenerator(targetClass, kinds))
-                addFrom(ResultSugarFunctionsCodeGenerator(targetClass, kinds))
+                addFrom(ResultContractClassCodeGenerator(element, targetClass, kinds))
+                addFrom(ResultClassCodeGenerator(element, targetClass, kinds))
+                addFrom(ResultSugarFunctionsCodeGenerator(element, targetClass, kinds))
             }
         }
     }

--- a/compile/src/main/java/com/juullabs/exercise/compile/generator/file/AsStubFileGenerator.kt
+++ b/compile/src/main/java/com/juullabs/exercise/compile/generator/file/AsStubFileGenerator.kt
@@ -30,13 +30,13 @@ internal class AsStubFileGenerator(
         val annotation = checkNotNull(element.getAnnotation<AsStub>())
         val targetClass = ClassName(annotation["packageName"] as String, annotation["className"] as String)
         return FileSpec.build(targetClass.packageName, "${targetClass.simpleName}ExerciseStubs") {
-            addFrom(ParameterizedIntentClassCodeGenerator(targetClass, parameters))
+            addFrom(ParameterizedIntentClassCodeGenerator(element, targetClass, parameters))
 
             val resultContractMirror = element.getAnnotation<ResultContract>()
             if (resultContractMirror != null) {
                 val kinds = getResultKinds(resultContractMirror)
-                addFrom(ResultContractClassCodeGenerator(targetClass, kinds))
-                addFrom(ResultClassCodeGenerator(targetClass, kinds))
+                addFrom(ResultContractClassCodeGenerator(element, targetClass, kinds))
+                addFrom(ResultClassCodeGenerator(element, targetClass, kinds))
             }
         }
     }

--- a/compile/src/main/java/com/juullabs/exercise/compile/generator/file/FragmentFileGenerator.kt
+++ b/compile/src/main/java/com/juullabs/exercise/compile/generator/file/FragmentFileGenerator.kt
@@ -4,11 +4,8 @@ import com.juullabs.exercise.compile.Parameters
 import com.juullabs.exercise.compile.build
 import com.juullabs.exercise.compile.generator.code.GetArgumentsClassCodeGenerator
 import com.juullabs.exercise.compile.generator.code.NewFragmentFunctionCodeGenerator
-import com.juullabs.exercise.compile.generator.code.GetParameterClassCodeGenerator
 import com.juullabs.exercise.compile.generator.code.addFrom
 import com.juullabs.exercise.compile.isSubtypeOfAny
-import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.asClassName
 import javax.annotation.processing.ProcessingEnvironment
@@ -28,9 +25,9 @@ internal class FragmentFileGenerator(
         val targetClass = element.asClassName()
         return FileSpec.build(targetClass.packageName, "${targetClass.simpleName}Exercise") {
             if (!element.modifiers.contains(Modifier.ABSTRACT)) {
-                addFrom(NewFragmentFunctionCodeGenerator(targetClass, parameters))
+                addFrom(NewFragmentFunctionCodeGenerator(element, targetClass, parameters))
             }
-            addFrom(GetArgumentsClassCodeGenerator(targetClass, parameters))
+            addFrom(GetArgumentsClassCodeGenerator(element, targetClass, parameters))
         }
     }
 }

--- a/compile/src/main/java/com/juullabs/exercise/compile/generator/file/FromStubFileGenerator.kt
+++ b/compile/src/main/java/com/juullabs/exercise/compile/generator/file/FromStubFileGenerator.kt
@@ -32,12 +32,12 @@ internal class FromStubFileGenerator(
         val parameters = Parameters(environment, source)
         val targetClass = element.asClassName()
         return FileSpec.build(targetClass.packageName, "${targetClass.simpleName}Exercise") {
-            addFrom(GetExtrasClassCodeGenerator(targetClass, parameters))
+            addFrom(GetExtrasClassCodeGenerator(element, targetClass, parameters))
 
             val resultContractMirror = source.getAnnotation<ResultContract>()
             if (resultContractMirror != null) {
                 val kinds = getResultKinds(resultContractMirror)
-                addFrom(ResultSugarFunctionsCodeGenerator(targetClass, kinds))
+                addFrom(ResultSugarFunctionsCodeGenerator(element, targetClass, kinds))
             }
         }
     }


### PR DESCRIPTION
Fixes warning where generated files don't properly attribute originating element, which broke incremental processing and forced full re-runs.

An example of this warning in the sample project, on my machine:
```
[WARN] Issue detected with com.juullabs.exercise.compile.ExerciseProcessor. Expected 1 originating source file when generating /mnt/c/Users/Cedrick Cooke/Github/exercise/application/build/generated/source/kapt/debug/com/juullabs/dynamicfeature/CalculatorChildActivityExerciseStubs.kt, but detected 0: [].
```